### PR TITLE
patch from jfearn++ to fix Win32 issue with library_ok

### DIFF
--- a/lib/Web/Library/Test.pm
+++ b/lib/Web/Library/Test.pm
@@ -48,7 +48,12 @@ sub include_path_ok {
                 $root = abs_path($root);
                 my @inc = get_manager()->include_paths;
                 is scalar(@inc), 1, 'there is only one include path';
-                like $inc[0], qr!^$root/.*\Q$version\E$!, 'include path';
+                if (File::Spec->case_tolerant()) {
+                    like abs_path($inc[0]), qr!^$root/.*\Q$version\E$!i, 'include path';
+                }
+                else {
+                    like $inc[0], qr!^$root/.*\Q$version\E$!, 'include path';
+                }
                 last;
             }
             $old_root = $root;


### PR DESCRIPTION
Hello!

This is an attempt to fix all the Win32 test failures that all modules using `library_ok()` are getting on CPAN Testers. It is based on issue #4 reported by @jfearn.

Hope this helps! Cheers!