### PR TITLE
support for perl 5.6 and above

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,3 +1,3 @@
-use 5.014000;
+use 5.006000;
 use Module::Build::Tiny 0.025;
 Build_PL();

--- a/lib/Web/Library.pm
+++ b/lib/Web/Library.pm
@@ -32,7 +32,8 @@ sub library_map {
     my %lib_by_name = map { $_->name => $_ } $self->all_libraries;
     my @result;
     for my $lib (@libs) {
-        my $item = $lib_by_name{$lib} // die "unknown library [$lib]";
+        my $item = $lib_by_name{$lib};
+        die "unknown library [$lib]" unless defined $item;
         local $_ = $item;    # so you can use $_ as well as $_[0] in $code
         push @result, $code->($item);
     }

--- a/lib/Web/Library/Provider.pm
+++ b/lib/Web/Library/Provider.pm
@@ -1,6 +1,5 @@
 package Web::Library::Provider;
 use Moose::Role;
-use 5.14.0;
 use File::Spec;
 use File::ShareDir ();
 use Cwd qw(abs_path);
@@ -26,7 +25,9 @@ sub dist_dir {
 
 sub dist_name {
     my $self = shift;
-    ref($self) =~ s/::/-/gr;
+    my $ref  = ref $self;
+    $ref     =~ s/::/-/g;
+    return $ref;
 }
 
 sub get_dir_for {

--- a/lib/Web/Library/SimpleAssets.pm
+++ b/lib/Web/Library/SimpleAssets.pm
@@ -4,7 +4,8 @@ requires qw(version_map);
 
 sub version_map_look_up {
     my ($self, $map, $version, $type) = @_;
-    my $submap = $map->{$version} // $map->{default};
+    my $submap = $map->{$version};
+    $submap = $map->{default} unless defined $submap;
     @{ $submap->{$type} };
 }
 


### PR DESCRIPTION
Hi! Me again!

It looks like some people want to use this distribution in very old environments with very old perls. This patch removes all uses of new features such as defined-or and non destructive regex substitutions to support perls as old as 5.6 (at least according to `perlver`).

Please note that If it were my project, I would **not** merge this, and keep pushing people to upgrade - specially since 5.14 is already pretty old, present in several dists, but more importantly because people should just bake their own perl with perlbrew or plenv instead of using the system's perl.

Hope it helps.